### PR TITLE
Fix VC features on Windows (and other things)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,24 @@ env:
     - secure: "x+C3fIhQlaTiVM58IcMqOcNQ2Lzb7Hl1po0a+02C3Q1w5HYY3fqpN43SnCi+chWYNI2BFB1sxLlqQy2f/LRvVN8TvmavtATvnD0XYFoQmmeOAEeXBN3kXdILOLwhw2rqZH4SLubHKLWUugLBER6wDxKG9u1QaTNPkNfWcOGilQQGGwNtP111nDXAyx1dAAZrqthBwu+vHdH0r3yL8AAzJKJL6mrCUZSijgmExf2P7v/s7GzjGlnlCVUUMlzN3CGPXgRBi1YHyKZAJPj28VNnU/GXH4hax0VTVBPzBOORBFevQYjjJJyE0H/7pa6cfGK4NA9LJfZlXmfYNW3hPb5F7ZaJOjLT5AMG3g3YLT0AuLg2FsvnAm3IAo2DPMZEMyYIHnM2dtYKAXyzdRmgWYx+mpxXFmJ57hMemOr5rpUmi3cCHxwRwpWxgtqvyNyahT5qUCMOP5/vj2h1ju+KtyXruYX/4vMz4WjWF5YhepIEMXDINgIk4QsBUURE4pBUPMtMx79rbsOSNmEPLN0ck6WuE9zQ5k/1T+ihujyzfnCSYW6QQbWeTea45s8fm5K+8D1SXB0GuDfPwRUGHM6quvoDtp8V97XjdgN62tEPgl8FqNeKEAD8mvJt/tYOIitkaD4FgGEQbZQcY1IkXNH2jZGOT6x2m1V9zfqKuCLywMrn3k0="
 
 
-before install:
+before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://github.com/hickford/primesieve-python
 
 Package license: MIT
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Fast prime number generator. Python bindings for primesieve C/C++ library
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,10 +72,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,14 @@ build:
 
 requirements:
   build:
-    - gcc     # [osx]
+    - gcc     # [unix]
     - python
     - cython
     - numpy x.x
     - primesieve
 
   run:
-    - libgcc  # [osx]
+    - libgcc  # [unix]
     - python
     - numpy x.x
     - primesieve

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   # Seem primesieve is encountering hangs on Windows with Python 2.7.
   # So, neither primesieve nor these Python bindings are built in that case.
   skip: true  # [win and py2k]
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   features:
     - vc10              # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ build:
   skip: true  # [win and py2k]
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
+  features:
+    - vc10              # [win and py34]
+    - vc14              # [win and py35]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,14 @@ build:
 
 requirements:
   build:
-    - gcc     # [unix]
+    - gcc               # [unix]
     - python
     - cython
     - numpy x.x
     - primesieve
 
   run:
-    - libgcc  # [unix]
+    - libgcc            # [unix]
     - python
     - numpy x.x
     - primesieve


### PR DESCRIPTION
Fixes https://github.com/conda-forge/python-primesieve-feedstock/issues/2

Explicitly adds the Windows feature tracking for VC based on Python here. This relies on this fix ( https://github.com/conda-forge/primesieve-feedstock/pull/1 ) to `primesieve` in order to work correctly. May need to restart to make sure we are using the right version of `primesieve` so we should wait for a bit.

Also, used `gcc` on all *NIXes to allow `libgomp` to be distributable.

Re-rendered with `conda-smithy` 0.9.2
