### PR TITLE
Remove the unnecessary `bld.bat`

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1


### PR DESCRIPTION
It use to be the case that `script` in `meta.yaml` was not respected by `conda-build` on Windows. However `conda-build` has long since been fixed. So this file is no longer necessary and can be dropped.